### PR TITLE
feat(socket): Add `socket` example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::{mem, ptr};
 
 // EXAMPLE: Prints the IP address of the given host.
-// Section 5.1 - getaddrinfo()
+// Section 5.1 - `getaddrinfo()` - Prepare to Launch!
 // MANPAGE: man 3 getaddrinfo
 pub fn showip(host: &str) -> Result<i32, i32> {
     let node = CString::new(host).unwrap();
@@ -11,6 +11,7 @@ pub fn showip(host: &str) -> Result<i32, i32> {
 
     let port: *const libc::c_char = ptr::null();
 
+    // SAFETY: hints is initialized as empty, but the required fields are set later on.
     let mut hints: libc::addrinfo = unsafe { mem::zeroed() };
     hints.ai_family = libc::AF_UNSPEC;
     hints.ai_socktype = libc::SOCK_STREAM;
@@ -65,4 +66,47 @@ pub fn showip(host: &str) -> Result<i32, i32> {
     }
 
     Ok(0)
+}
+
+// EXAMPLE: Showcases how socket() can be used.
+// Section 5.2 - `socket()` - Get the File Descriptor!
+// MANPAGE: man 3 socket
+pub fn socket() -> Result<i32, i32> {
+    let node = CString::new("www.example.com").unwrap();
+    let node_ptr = node.as_ptr();
+
+    let service = CString::new("http").unwrap();
+    let service_ptr = service.as_ptr();
+
+    // SAFETY: hints is initialized as empty, but the required fields are set later on.
+    let mut hints: libc::addrinfo = unsafe { mem::zeroed() };
+    hints.ai_family = libc::AF_INET;
+    hints.ai_socktype = libc::SOCK_STREAM;
+
+    let mut res_ptr: *mut libc::addrinfo = ptr::null_mut();
+
+    // SAFETY: all the required vars are initialized for getaddrinfo().
+    // gai_stderror() is used for error cases only.
+    unsafe {
+        let s = libc::getaddrinfo(node_ptr, service_ptr, &hints, &mut res_ptr);
+        if s != 0 {
+            eprintln!("getaddrinfo error: {}", *libc::gai_strerror(s));
+            return Err(s);
+        }
+    }
+
+    unsafe {
+        let res = *res_ptr;
+        let sock_fd = libc::socket(res.ai_family, res.ai_socktype, res.ai_protocol);
+        if sock_fd == -1 {
+            eprintln!("socket error: {}", *libc::strerror(sock_fd));
+            return Err(sock_fd);
+        }
+
+        println!("created sock fd: {}", sock_fd);
+
+        libc::freeaddrinfo(res_ptr);
+
+        Ok(sock_fd)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ fn main() -> ExitCode {
 
     let result = match cli.examples {
         Examples::ShowIp { host } => beej_net_rs::showip(&host),
+        Examples::Socket => beej_net_rs::socket(),
     };
 
     match result {
@@ -27,7 +28,11 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Examples {
-    /// Section 5.1 - getaddrinfo()
+    /// Section 5.1 - `getaddrinfo()` - Prepare to Launch!
     #[clap(name = "showip")]
     ShowIp { host: String },
+
+    /// Section 5.2 - `socket()` - Get the File Descriptor!
+    #[clap(name = "sock")]
+    Socket,
 }


### PR DESCRIPTION
This example just showcases how `socket` is used in the most basic sense.

It is not a simple app example like `showip`, that is why the received socket file descriptor is just printed to the output.

Along with this change, the full title of `getaddrinfo` section is added to the project.