### PR TITLE
feat(safety-comments): Add missing SAFETY comments

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -38,30 +38,39 @@ pub fn socket() -> Result<(), Error> {
     hints.ai_family = libc::AF_INET;
     hints.ai_socktype = libc::SOCK_STREAM;
 
-    let mut res_ptr: *mut libc::addrinfo = ptr::null_mut();
+    let mut res_ptr = ptr::null_mut();
 
     // SAFETY: all the required vars are initialized for getaddrinfo().
     // gai_stderror() is used for error cases only.
-    let sock_fd = unsafe {
+    unsafe {
         let s = libc::getaddrinfo(node_ptr, service_ptr, &hints, &mut res_ptr);
         if s != 0 {
             let err = CStr::from_ptr(libc::gai_strerror(s)).to_string_lossy();
-            return Err(Error::Getaddrinfo(err.into_owned()));
+            Err(Error::Getaddrinfo(err.into_owned()))
+        } else {
+            Ok(())
         }
+    }?;
 
+    // SAFETY: `res_ptr` is initialized upon a successful getaddrinfo() call.
+    // Therefore we can guarantee that there is atleast one addrinfo that `res_ptr` points to, making deref safe.
+    let sock_fd = unsafe {
         let res = *res_ptr;
-
         let sock_fd = libc::socket(res.ai_family, res.ai_socktype, 0);
         if sock_fd == -1 {
             let err = io::Error::last_os_error();
             return Err(Error::Socket(err));
         }
 
-        libc::freeaddrinfo(res_ptr);
         sock_fd
     };
 
     println!("created sock fd: {}", sock_fd);
+
+    // SAFETY: `res_ptr` will not be used after this call, therefore it is safe to free it.
+    unsafe {
+        libc::freeaddrinfo(res_ptr);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Each unsafe operation is explained in detail by using `SAFETY` comments above them as much as possible.