### PR TITLE
feat(close): Add `close` example

### DIFF
--- a/src/close.rs
+++ b/src/close.rs
@@ -1,0 +1,131 @@
+use std::{
+    error,
+    ffi::{CStr, CString},
+    fmt, io, mem, ptr,
+};
+
+#[derive(Debug)]
+pub enum Error {
+    Getaddrinfo(String),
+    Socket(io::Error),
+    Close(i32, io::Error),
+    Send(i32, io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Getaddrinfo(err) => write!(f, "getaddrinfo error: {}", err),
+            Error::Socket(err) => write!(f, "socket err: {}", err),
+            Error::Close(sock_fd, err) => write!(
+                f,
+                "close err on sock fd {}: {}
+                ",
+                sock_fd, err
+            ),
+            Error::Send(sock_fd, err) => write!(f, "send err on sock fd {}: {}", sock_fd, err),
+        }
+    }
+}
+impl error::Error for Error {}
+
+// EXAMPLE: Attempt to send a message on a closed socket via `close()`.
+// MANPAGE:
+// man 2 close (Linux)
+// man 3 close (POSIX)
+// man errno
+pub fn close() -> Result<(), Error> {
+    let node = ptr::null();
+    let port = CString::from(c"3490");
+
+    // SAFETY: hints is initialized as empty, but the required fields are set later on.
+    let mut hints: libc::addrinfo = unsafe { mem::zeroed() };
+    hints.ai_family = libc::AF_UNSPEC;
+    hints.ai_socktype = libc::SOCK_DGRAM;
+
+    let mut res_ptr: *mut libc::addrinfo = ptr::null_mut();
+
+    // SAFETY:
+    // 1 - All the required vars are initialized for getaddrinfo().
+    // 2 - gai_stderror() is used for error cases only.
+    unsafe {
+        let ecode = libc::getaddrinfo(node, port.as_ptr(), &hints, &mut res_ptr);
+        match ecode {
+            0 => Ok(()),
+            _ => {
+                let err = CStr::from_ptr(libc::gai_strerror(ecode)).to_string_lossy();
+                Err(Error::Getaddrinfo(err.into_owned()))
+            }
+        }
+    }?;
+
+    // SAFETY:
+    // 1 - Since we are trying to get our loopback IP address via `getaddrinfo()`, we know that `res_ptr` points to an initialized memory, making `socket()` safe to use.
+    // 2 - Any potential `socket()` error is checked by reading `errno` instantly after the `socket()` call. This ensures that `sock_fd` contains the fd of a successfully created socket.
+    let sock_fd = unsafe {
+        let res = *res_ptr;
+
+        let fd = libc::socket(res.ai_family, res.ai_socktype, 0);
+        match fd {
+            -1 => {
+                let err = io::Error::last_os_error();
+                Err(Error::Socket(err))
+            }
+            _ => Ok(fd),
+        }
+    }?;
+
+    // SAFETY:
+    // 1 - `sock_fd` points to a valid socket file descriptor created by `socket()`.
+    // 2 - Any potential `close()` error is checked by reading `errno` instantly after the `close()` call.
+    unsafe {
+        let ecode = libc::close(sock_fd);
+        match ecode {
+            -1 => {
+                let err = io::Error::last_os_error();
+                Err(Error::Close(sock_fd, err))
+            }
+            _ => Ok(()),
+        }
+    }?;
+
+    let buf = b"will this message be able to go through?";
+    let len = buf.len();
+
+    // SAFETY:
+    // 1 - `sock_fd` points to a valid socket file descriptor created by `socket()`.
+    // 2 - `res_ptr` points to a valid memory filled via `getaddrinfo()`.
+    // 3 - The fixed message buf is initialized as a simple byte array.
+    // 4 - Any potential `sendto()` error is checked by reading `errno` instantly after the `sendto()` call.
+    // 5 - Since `res_ptr` is not used after `sendto()`, it can be freed without any side effects.
+    let sent_bytes = unsafe {
+        let res = *res_ptr;
+
+        let bytes = libc::sendto(
+            sock_fd,
+            buf.as_ptr() as _,
+            len,
+            0,
+            res.ai_addr,
+            res.ai_addrlen,
+        );
+
+        let send_res = match bytes {
+            -1 => {
+                let err = io::Error::last_os_error();
+                Err(Error::Send(sock_fd, err))
+            }
+            _ => Ok(bytes),
+        };
+
+        libc::freeaddrinfo(res_ptr);
+
+        send_res
+    }?;
+
+    // We cannot reach the line below.
+    // If you check the diagnostic message and compare it with errno values, you will see that `sendto()` fails with err `EBADF` err code.
+    println!("sent {} bytes", sent_bytes);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod accept;
 mod bind;
+mod close;
 mod connect;
 mod listen;
 mod recv;
@@ -11,6 +12,7 @@ mod socket;
 
 pub use accept::accept;
 pub use bind::{bind, reuse_port};
+pub use close::close;
 pub use connect::connect;
 pub use listen::listen;
 pub use recv::recv;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
         Examples::Recv => beej_net_rs::recv()?,
         Examples::Sendto => beej_net_rs::sendto()?,
         Examples::Recvfrom => beej_net_rs::recvfrom()?,
+        Examples::Close => beej_net_rs::close()?,
     };
 
     Ok(())
@@ -104,4 +105,7 @@ pub enum Examples {
     /// Send a UDP message from a separate terminal session by using `ncat -u 127.0.0.1 3490 <<< "hello UDP message!"` or via any command you prefer.
     /// Observe that the message "hello UDP message!" appears on our process' terminal session.
     Recvfrom,
+
+    /// Section 5.9 - `close() and shutdown()` - Get outta my face!
+    Close,
 }

--- a/src/recvfrom.rs
+++ b/src/recvfrom.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {}
 
 // EXAMPLE: Receive a message that comes to a named SOCK_DGRAM socket on localhost (INET), on port 3490.
-// MANPAGES:
+// MANPAGE:
 // man 2 recvfrom (Linux)
 // man 3 recvfrom (POSIX)
 pub fn recvfrom() -> Result<(), Error> {

--- a/src/sendto.rs
+++ b/src/sendto.rs
@@ -24,7 +24,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {}
 
 // EXAMPLE: Send a message via a SOCK_DGRAM socket to the UDP server on localhost (INET), on port 3490.
-// MANPAGES:
+// MANPAGE:
 // man 2 sendto (Linux)
 // man 3 sendto (POSIX)
 pub fn sendto() -> Result<(), Error> {


### PR DESCRIPTION
Since there were no examples about this syscall, I added a trivial one by attempting to send a message through a socket file descriptor that was closed via `close()` before.