### PR TITLE
feat(blocking): Add Section 7.1 example

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,0 +1,65 @@
+use std::{error, fmt, io, ptr};
+
+#[derive(Debug)]
+pub enum Error {
+    Socket(io::Error),
+    Fcntl(io::Error),
+    Recv(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Socket(err) => write!(f, "socket error: {}", err),
+            Error::Fcntl(err) => write!(f, "fcntl error: {}", err),
+            Error::Recv(err) => write!(f, "recv error: {}", err),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
+// EXAMPLE: Attempt to recv from a non-blocking socket.
+// MANPAGE:
+// man 2 fcntl (Linux)
+// man 3 fcntl (POSIX)
+// man errno
+pub fn blocking() -> Result<(), Error> {
+    // SAFETY: There are no reads to uninitialized memory, making `socket()` safe to use.
+    let sock = unsafe { libc::socket(libc::PF_INET, libc::SOCK_DGRAM, 0) };
+    match sock {
+        -1 => Err(Error::Socket(io::Error::last_os_error())),
+        _ => Ok(()),
+    }?;
+
+    // SAFETY: `fnctl()` is called on a valid socket.
+    let res = unsafe { libc::fcntl(sock, libc::F_SETFL, libc::O_NONBLOCK) };
+    match res {
+        -1 => Err(Error::Fcntl(io::Error::last_os_error())),
+        _ => Ok(()),
+    }?;
+
+    // SAFETY: There are no reads to uninitialized memory, making `recvfrom()` safe to use.
+    let bytes = unsafe {
+        libc::recvfrom(
+            sock,
+            [0; 1].as_mut_ptr() as *mut libc::c_void,
+            1,
+            0,
+            ptr::null_mut(),
+            ptr::null_mut(),
+        )
+    };
+    match bytes {
+        // NOTE: EAGAIN or EWOULDBLOCK may be received from the OS.
+        // Search the err message in `man errno` to find our the exact err code.
+        -1 => Err(Error::Recv(io::Error::last_os_error())),
+        _ => Ok(()),
+    }?;
+
+    // Bytes are intentionally printed here to observe that the process
+    // cannot reach the line below.
+    println!("received {} bytes", bytes);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod accept;
 mod bind;
+mod blocking;
 mod close;
 mod connect;
 mod dgram;
@@ -17,6 +18,7 @@ mod stream;
 
 pub use accept::accept;
 pub use bind::{bind, reuse_port};
+pub use blocking::blocking;
 pub use close::close;
 pub use connect::connect;
 pub use dgram::{client as dgram_client, server as dgram_server};

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ fn run() -> Result<(), Box<dyn error::Error>> {
             DgramCommand::Server => beej_net_rs::dgram_server()?,
             DgramCommand::Client => beej_net_rs::dgram_client()?,
         },
+        Example::Blocking => beej_net_rs::blocking()?,
     };
 
     Ok(())
@@ -152,6 +153,9 @@ pub enum Example {
         #[command(subcommand)]
         cmd: DgramCommand,
     },
+
+    /// Section 7.1 - Blocking
+    Blocking,
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
To demonstrate the difference between blocking and non-blocking, an arbitrary non-blocking socket is created via `O_NONBLOCK` flag.

The example showcases the errors received from the OS when a process tries to receive from a non-blocking socket.