### PR TITLE
fix(dgram-client): Connect to UDP srv using AF_INET

### DIFF
--- a/src/dgram/client.rs
+++ b/src/dgram/client.rs
@@ -33,7 +33,7 @@ pub fn client() -> Result<(), Error> {
     // SAFETY: All zero hints is a valid initialization.
     // Required fields are set later on.
     let mut hints: libc::addrinfo = unsafe { mem::zeroed() };
-    hints.ai_family = libc::AF_INET6;
+    hints.ai_family = libc::AF_INET;
     hints.ai_socktype = libc::SOCK_DGRAM;
 
     let mut gai_res_ptr: *mut libc::addrinfo = ptr::null_mut();


### PR DESCRIPTION
The UDP server was changed to listen on `AF_INET`, instead of `AF_INET6` due to the `broadcaster` example.

Therefore, the UDP client example is fixed to reflect this change.